### PR TITLE
Do not randomize the listening port if certain is specified

### DIFF
--- a/server/ssh.go
+++ b/server/ssh.go
@@ -284,10 +284,10 @@ listen:
 	ln, err := net.Listen("tcp", bind)
 	if err != nil {
 		s.logger.Errorf("[%s] listen failed for: %s %v, retrying on another port", client.id, bind, err)
-		if payload.Port != 0 {
-			payload.Port = 0
+		if payload.Port == 0 {
+			goto listen
 		}
-		goto listen
+		return nil, nil, err
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
 	bind = fmt.Sprintf("%s:%d", payload.Addr, port)


### PR DESCRIPTION
If a user has requested a specific listening port, he expects to get this port, or a failure.
The randomization should be performed only if a user doesn't care which port will be issued.