### PR TITLE
Fix for incomplete error handling

### DIFF
--- a/server/ssh.go
+++ b/server/ssh.go
@@ -200,6 +200,7 @@ func (s *SSHServer) handleRequests(client *client, reqs <-chan *ssh.Request) {
 			if err != nil {
 				s.logger.Errorf("[%s] error, disconnecting: %v", client.id, err)
 				client.tcpConn.Close()
+				continue
 			}
 
 			client.addr = bindInfo.Addr

--- a/server/ssh.go
+++ b/server/ssh.go
@@ -283,10 +283,11 @@ listen:
 
 	ln, err := net.Listen("tcp", bind)
 	if err != nil {
-		s.logger.Errorf("[%s] listen failed for: %s %v, retrying on another port", client.id, bind, err)
 		if payload.Port == 0 {
+			s.logger.Errorf("[%s] listen failed for: %s %v, retrying on another port", client.id, bind, err)
 			goto listen
 		}
+		s.logger.Errorf("[%s] listen failed for: %s %v", client.id, bind, err)
 		return nil, nil, err
 	}
 	port := ln.Addr().(*net.TCPAddr).Port

--- a/server/ssh.go
+++ b/server/ssh.go
@@ -288,7 +288,8 @@ listen:
 			goto listen
 		}
 		s.logger.Errorf("[%s] listen failed for: %s %v", client.id, bind, err)
-		return nil, nil, err
+		req.Reply(false, []byte{})
+		return nil, nil, fmt.Errorf("unable to listen")
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
 	bind = fmt.Sprintf("%s:%d", payload.Addr, port)


### PR DESCRIPTION
- Fix for #24 
- Replying with an error to the client so that it will get "tcpip-forward request denied" instead of obscure "EOF"