### PR TITLE
fix(client): check local port before server dial

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -40,6 +40,13 @@ func NewBoreClient(config Config) BoreClient {
 
 // Run starts the client.
 func (c *BoreClient) Run() error {
+	// Healthcheck
+	local, err := net.Dial("tcp", c.LocalEndpoint.String())
+	if err != nil {
+		return err
+	}
+	_ = local.Close()
+
 	ch := make(chan os.Signal, 1)
 	errch := make(chan error)
 	signal.Notify(ch, os.Interrupt)


### PR DESCRIPTION
Hello, we are using your bore proxy implementation and we are quite impressed.

We have just one small problem: the server is already responding to us with a generated port/address while the local port is not yet open.

The logs look like this:

```
Generated HTTP URL: http://1700f3b3.my.bore.server/
Generated HTTPS URL: https://1700f3b3.my.bore.server/
Direct TCP: tcp://my.bore.server:56021

2023/03/30 20:41:44 connection failed due: dial tcp [::1]:2022: connect: connection refused reconnecting in 5s...  
Generated HTTP URL: http://c8102b0f.my.bore.server/
Generated HTTPS URL: https://c8102b0f.my.bore.server/
Direct TCP: tcp://my.bore.server:62595

2023/03/30 20:41:50 connection failed due: dial tcp [::1]:2022: connect: connection refused reconnecting in 5s...  
Generated HTTP URL: http://b7a8d75b.my.bore.server/
Generated HTTPS URL: https://b7a8d75b.my.bore.server/
Direct TCP: tcp://my.bore.server:64315

```

A simple solution would be to check the local port in advance.