### PR TITLE
feat: implement password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ BORE_DOMAIN=bore.digital BORE_HTTPADDR=0.0.0.0:80 BORE_SSHADDR=0.0.0.0:2200 ./bu
 
 This will generate initial config at `~/bore/bore-server.yaml` with values you provided over environment variables.
 
+## Running With Password Authentication
+To enable password authentication, you can set it up with the `BORE_PASSWORD` environment variable:
+
+### Server Side 
+```sh 
+BORE_DOMAIN=example.com BORE_HTTPADDR=0.0.0.0:80 BORE_SSHADDR=0.0.0.0:2200 BORE_PASSWORD=mysecreetpassword ./build/bore-server
+```
+### Client Side
+Use the `-pw` flag to provide the password when connecting to the server:
+
+```sh
+bore -s example.com -p 2200 -ls localhost -lp 6500 -pw mysecreetpassword
+```
+If the password is incorrect or not provided when required, the connection will be rejected with an authentication error.
+
 ## License
 
 ```license

--- a/client/config.go
+++ b/client/config.go
@@ -9,4 +9,5 @@ type Config struct {
 	BindPort     int
 	ID           string
 	KeepAlive    bool
+	Password     string
 }

--- a/cmd/bore/main.go
+++ b/cmd/bore/main.go
@@ -28,6 +28,8 @@ Options:
 
 -id, ID to use when generating URL (default: "" (random))
 
+-pw, Password for remote server authentication (default: "")
+
 -a, Keep tunnel connection alive (default: true)
 
 -r, Auto-reconnect if connection failed (default: false)
@@ -45,6 +47,7 @@ var (
 	localPort     = flag.Int("lp", 80, "")
 	bindPort      = flag.Int("bp", 0, "")
 	id            = flag.String("id", "", "")
+	password      = flag.String("pw", "", "")
 	keepAlive     = flag.Bool("a", true, "")
 	autoReconnect = flag.Bool("r", false, "")
 	versionFlag   = flag.Bool("version", false, "version")
@@ -69,6 +72,7 @@ func main() {
 		LocalPort:    *localPort,
 		BindPort:     *bindPort,
 		ID:           *id,
+		Password:     *password,
 		KeepAlive:    *keepAlive,
 	})
 

--- a/server/options.go
+++ b/server/options.go
@@ -20,6 +20,7 @@ type Options struct {
 	PublicKey  string
 	SSHAddr    string
 	HTTPAddr   string
+	Password   string
 	Logger     *logger.Options
 }
 
@@ -37,6 +38,7 @@ func NewConfig(configPath string) (*viper.Viper, error) {
 	v.SetDefault("publickey", filepath.Join(dir, "id_rsa.pub"))
 	v.SetDefault("sshaddr", "0.0.0.0:2200")
 	v.SetDefault("httpaddr", "0.0.0.0:2000")
+	v.SetDefault("password", "")
 	v.SetDefault("log.level", "debug")
 	v.SetDefault("log.stdout", true)
 	v.SetDefault("log.filename", filepath.Join(dir, "bore-server.log"))

--- a/server/types.go
+++ b/server/types.go
@@ -28,6 +28,10 @@ type idRequestPayload struct {
 	ID string
 }
 
+type passwordRequestPayload struct {
+	Password string
+}
+
 type clientResponse struct {
 	id     string
 	port   uint32


### PR DESCRIPTION
Hello @jkuri thank you for creating this awesome tool!  

I have added an authentication feature for both the server and client, based on feature request #42 
The authentication method works similarly to `set-id`, where the client must provide a password to connect to the server.  

### **Usage**  

#### **Server**  
```sh
BORE_PASSWORD=mysecretpassword BORE_DOMAIN=example.com BORE_HTTPADDR=0.0.0.0:80 BORE_SSHADDR=0.0.0.0:2200 ./build/bore-server
```

#### **Client**  
```sh
./build/bore -s example.com -p 2200 -ls localhost -lp 6500 -pw mysecretpassword
```

Please review the changes, and let me know if there's anything that needs improvement.  
Looking forward to your feedback. Thanks!  